### PR TITLE
fix: paths to api files in production mode

### DIFF
--- a/adonis-typings/index.ts
+++ b/adonis-typings/index.ts
@@ -1,4 +1,22 @@
 declare module '@ioc:Adonis/Addons/Swagger' {
+	export interface JsDocConfig {
+		definition: {
+			openapi?: string
+
+			info: {
+				title: string
+
+				version: string
+
+				description: string
+			}
+		}
+
+		apis: string[]
+
+		basePath?: string
+	}
+
 	export interface SwaggerConfig {
 		uiEnabled: boolean //disable or enable swaggerUi route
 		uiUrl: string // url path to swaggerUI
@@ -7,22 +25,6 @@ declare module '@ioc:Adonis/Addons/Swagger' {
 
 		middleware: string[] // middlewares array, for protect your swagger docs and spec endpoints
 
-		options: {
-			definition: {
-				openapi?: string
-
-				info: {
-					title: string
-
-					version: string
-
-					description: string
-				}
-			}
-
-			apis: string[]
-
-			basePath?: string
-		}
+		options: JsDocConfig
 	}
 }

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            August 4th 2020, 11:50:02 am
+                            October 20th 2020, 9:19:11 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/providers/SwaggerProvider.ts
+++ b/providers/SwaggerProvider.ts
@@ -6,6 +6,7 @@ import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 import { promises } from 'fs'
 import { join } from 'path'
 import mime from 'mime'
+import buildJsDocConfig from '../src/Utils/buildJsDocConfig'
 
 export default class SwaggerProvider {
 	constructor(protected container: IocContract) {}
@@ -49,7 +50,7 @@ export default class SwaggerProvider {
 		if (config.get('swagger.specEnabled', true)) {
 			router
 				.get(config.get('swagger.specUrl'), () => {
-					return swaggerJSDoc(config.get('swagger.options', {}))
+					return swaggerJSDoc(buildJsDocConfig(config.get('swagger.options', {})))
 				})
 				.middleware(config.get('swagger.middleware', []) as string[])
 		}

--- a/src/Utils/buildJsDocConfig.ts
+++ b/src/Utils/buildJsDocConfig.ts
@@ -1,0 +1,9 @@
+import resolveApiPaths from './resolveApis'
+import { JsDocConfig } from '@ioc:Adonis/Addons/Swagger'
+
+export default function ({ apis, ...restOptions }: JsDocConfig): JsDocConfig {
+	return {
+		...restOptions,
+		apis: resolveApiPaths(apis),
+	}
+}

--- a/src/Utils/resolveApis.ts
+++ b/src/Utils/resolveApis.ts
@@ -1,0 +1,9 @@
+import { join } from 'path'
+
+export default function (paths: string[]) {
+	const isBuildDir: boolean = process.cwd().includes('build')
+
+	return paths.map((path) => {
+		return isBuildDir ? join('..', path) : path
+	})
+}

--- a/templates/config.txt
+++ b/templates/config.txt
@@ -19,9 +19,9 @@ export default {
 		},
 
 		apis: [
-			'./../app/**/*.ts',
-			'./../docs/swagger/**/*.yml',
-			'./../start/routes.ts'
+			'app/**/*.ts',
+			'docs/swagger/**/*.yml',
+			'start/routes.ts'
 		],
 		basePath: '/'
 	}

--- a/test/fixtures/swagger-config.json
+++ b/test/fixtures/swagger-config.json
@@ -13,7 +13,7 @@
 				"description": "My application with swagger docs"
 			}
 		},
-		"apis": ["./../app/**/*.ts", "./../docs/swagger/**/*.yml", "./../start/routes.ts"],
+		"apis": ["app/**/*.ts", "docs/swagger/**/*.yml", "start/routes.ts"],
 		"basePath": "/"
 	}
 }

--- a/test/swagger-e2e.spec.ts
+++ b/test/swagger-e2e.spec.ts
@@ -5,17 +5,13 @@ import { Filesystem } from '@poppinss/dev-utils'
 import { Ignitor } from '@adonisjs/core/build/src/Ignitor'
 import { setupApplicationFiles } from '../test-helpers'
 import { createServer } from 'http'
-import { promises as fs } from 'fs'
 import swaggerResponse from './fixtures/swagger.json'
 import swaggerConfig from './fixtures/swagger-config.json'
+import SwaggerProvider from '../providers/SwaggerProvider'
 
 async function initServerWithSwaggerConfig(vfs: Filesystem, config) {
-	await vfs.add(
-		'providers/SwaggerProvider.ts',
-		await fs.readFile(join(__dirname, '/../providers/SwaggerProvider.ts'), 'utf-8')
-	)
 	await vfs.add('config/swagger.json', JSON.stringify(config))
-	await setupApplicationFiles(vfs, ['./providers/SwaggerProvider.ts'])
+	await setupApplicationFiles(vfs, [])
 	const ignitor = new Ignitor(vfs.basePath)
 	const bootstrapper = ignitor.boostrapper()
 	const httpServer = ignitor.httpServer()
@@ -24,6 +20,10 @@ async function initServerWithSwaggerConfig(vfs: Filesystem, config) {
 	bootstrapper.registerAliases()
 	bootstrapper.registerProviders(false)
 	await bootstrapper.bootProviders()
+
+	const provider = new SwaggerProvider(application.container)
+	await provider.register()
+	await provider.boot()
 
 	const app = application.container.use('Adonis/Core/Server')
 	application.container.use('Adonis/Core/Route').get('/', () => 'handled')


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Resolve paths to files with js-doc from build dir. It is broken swagger api paths, when you run swagger in production mode.

## Types of changes

What types of changes does your code introduce?
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/reg2005/adonis5-swagger/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

