### PR TITLE
fix: redirect to configured uiUrl when no fileName is provided

### DIFF
--- a/src/SwaggerController.ts
+++ b/src/SwaggerController.ts
@@ -20,7 +20,8 @@ export class SwaggerController {
 		const swaggerUiAssetPath =
 			this.config.get('swagger.swaggerUiDistPath') || require('swagger-ui-dist').getAbsoluteFSPath()
 		if (!params.fileName) {
-			return response.redirect('/docs/index.html')
+			const baseUrl = this.config.get('swagger.uiUrl', '/docs').replace('/', '')
+			return response.redirect(`/${baseUrl}/index.html`)
 		}
 		let fileName = params.fileName ? params.fileName : 'index.html'
 		const path = join(swaggerUiAssetPath, fileName)


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Redirect to configured `uiUrl` when no fileName is provided in `SwaggerController`.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/reg2005/adonis5-swagger/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
